### PR TITLE
Allow interactive passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Very simply:
 ```
     sudo ./nxBender --server my-sslvpn-host.com -u username -p password -d domainname
 ```
+`-p password`  is optional, if not supplied it will ask interactively on the commandline
 
 You can supply the server's SSL certificate fingerprint with `--fingerprint` if
 you're using self-signed certificates or if you want pinning.

--- a/nxbender/__init__.py
+++ b/nxbender/__init__.py
@@ -3,6 +3,7 @@ import configargparse
 import requests
 import sslconn
 import logging
+import getpass
 
 parser = configargparse.ArgumentParser(
         description='Connect to a netExtender VPN',
@@ -14,7 +15,7 @@ parser.add_argument('-c', '--conf', is_config_file=True)
 parser.add_argument('-s', '--server', required=True)
 parser.add_argument('-P', '--port', type=int, default=443, help='Server port - default 443')
 parser.add_argument('-u', '--username', required=True)
-parser.add_argument('-p', '--password', required=True)
+parser.add_argument('-p', '--password', required=False)
 parser.add_argument('-d', '--domain', required=True)
 
 parser.add_argument('-f', '--fingerprint', help='Verify server\'s SSL certificate has this fingerprint. Overrides all other certificate verification.')
@@ -30,6 +31,9 @@ def main():
         loglevel = logging.WARNING
     else:
         loglevel = logging.INFO
+
+    if not args.password:
+        args.password = getpass.getpass()
 
     logging.basicConfig(level=loglevel, format='%(levelname)s: %(message)s')
 


### PR DESCRIPTION
In many cases it is not wanted to supply the password as parameter or in a configuration file. I added interactive password input as an alterantive to supply it on the commandline