### PR TITLE
Remove dependency on ipaddress package.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ConfigArgParse
-ipaddress
 pyroute2
 requests
 colorlog

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(name='nxBender',
       },
       install_requires=[
           'ConfigArgParse',
-          'ipaddress',
           'pyroute2',
           'requests',
           'colorlog',


### PR DESCRIPTION
A trivial change, but makes it usable on Gentoo / AMD64 / Python 3.7:

The ipaddress module is part of the python standard library from python 3.3 onwards, i.e. every maintained version of python. I found that having the dependency on ipaddress in setup.py broke nxBender on Python 3.7 (would not start with an error about not being able to find the package), so remove the dependency.

Error before this change:
```
$ nxBender
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.7/nxBender", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3251, in <module>
    @_call_aside
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.7/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'ipaddress' distribution was not found and is required by nxBender
```