### PR TITLE
Limit the size of data packets to less than mtu

### DIFF
--- a/nxbender/__init__.py
+++ b/nxbender/__init__.py
@@ -18,7 +18,7 @@ parser.add_argument('-p', '--password', required=False)
 parser.add_argument('-d', '--domain', required=True)
 
 parser.add_argument('-f', '--fingerprint', help='Verify server\'s SSL certificate has this fingerprint. Overrides all other certificate verification.')
-parser.add_argument('-m', '--mtu', type=int, default=1280, help='Connection Maximum Transmission Unit (MTU), used to determine size of packets sent to server.')
+parser.add_argument('-m', '--max-line', type=int, default=1514, help='Maximum length of a single line of PPP data sent to the server')
 
 parser.add_argument('--debug', action='store_true', help='Show debugging information')
 parser.add_argument('-q', '--quiet', action='store_true', help='Don\'t output basic info whilst running')

--- a/nxbender/sslconn.py
+++ b/nxbender/sslconn.py
@@ -56,9 +56,6 @@ class SSLTunnel(SSLConnection):
 
         self.buf = b''
         self.wbuf = b''
-        # Set the length of lines over the TLS connection to ensure result fits in one packet.
-        # Overhead is 2 bytes at start, 2 bytes line ending
-        self.line_length = self.options.mtu - 4
 
     def fileno(self):
         return self.s.fileno()
@@ -111,7 +108,7 @@ class SSLTunnel(SSLConnection):
 
     def write_pump(self):
         while len(self.wbuf):
-            packet = self.wbuf[:self.line_length]
+            packet = self.wbuf[:self.options.max_line]
             buf = struct.pack('>L', len(packet)) + packet
             self.s.sendall(buf)
             self.wbuf = self.wbuf[len(packet):]


### PR DESCRIPTION
Default the limit to 1280 bytes, which I'm guessing may match the NetExtender client. Allow users to increase or decrease this if necessary for their server and internet path.

I think this may fix #11, it certainly fixes a similar problem for me (triggered by upstream packets in particular).